### PR TITLE
Fix theme definition

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,13 +1,13 @@
 baseurl = "https://meptrsn.github.io/blog/"
 languageCode = "en-us"
 title = "meptrsn"
+theme = "paperback"
 [params]
 authorname = "Matthew Petersen"
 githubusername = "meptrsn"
 homepageposts = 10
 sociallinks = true
 tagline = "Engineering, Assyriology, and games."
-theme = "paperback"
 twitterusername = "meptrsn"
 [taxonomies]
 category = "categories"


### PR DESCRIPTION
The theme definition was nested under [params], which caused it to be ignored at build time